### PR TITLE
fix(policy): add line terminator so ABNF compiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ subselector = "." CHAR string                           ; Dotted field selector
 ;; SPECIAL LITERALS
 
 pattern     = DQUOTE string DQUOTE ; Reminder: IPLD strings are UTF-8
-number      = integer / float
+number      = integer / float ;
 ```
  
 ## Comparisons

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ subselector = "." CHAR string                           ; Dotted field selector
 ;; SPECIAL LITERALS
 
 pattern     = DQUOTE string DQUOTE ; Reminder: IPLD strings are UTF-8
-number      = integer / float ;
+number      = integer / float
 ```
  
 ## Comparisons

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ null
 
 [jq] is a much larger language than UCAN's selectors. jq includes features like pipes, arithmatic, regexes, assignment, recursive descent, and so on which MUST NOT be supported in the UCAN Policy language.
 
-jq produces streams of values, in contract to UCAN argument selectors which return an IPLD value. This introduces the primary difference between jq and UCAN argument selectors is how to treat output of the try (`?`) operator: UCAN's `try` selector operator MUST return `null` for the failure case.
+jq produces streams of values, in contrast to UCAN argument selectors which return an IPLD value. This introduces the primary difference between jq and UCAN argument selectors is how to treat output of the try (`?`) operator: UCAN's `try` selector operator MUST return `null` for the failure case.
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ connective  = "[" DQUOTE "not" DQUOTE ","  statement "]"                    ; Ne
             / "[" DQUOTE "and" DQUOTE ",[" statement *("," statement) "]]" ; Conjuction
             / "[" DQUOTE "or"  DQUOTE ",[" statement *("," statement) "]]" ; Disjunction
 
-quanitifier = "[" DQUOTE "every" DQUOTE "," selector "," policy "]" ; Universal
+quantifier  = "[" DQUOTE "every" DQUOTE "," selector "," policy "]" ; Universal
             / "[" DQUOTE "some"  DQUOTE "," selector "," policy "]" ; Existential
 
 ;; COMPARISONS


### PR DESCRIPTION
This PR adds a line terminator to the last line of the `policy` ABNF - when I was generating a parser from the grammar, I was missing `number` in my output.